### PR TITLE
fix: use BTreeMap to preserve keys' order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 [[package]]
 name = "boolify"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/boolify?rev=8766836#8766836d93cdf427fae0b0b612b94443c20d5b28"
+source = "git+https://github.com/voltrevo/boolify?rev=eaabb17#eaabb17835460e2e7d89f5fdc8d2422106728744"
 dependencies = [
  "bristol-circuit",
  "serde",
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 name = "bristol-circuit"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/bristol-circuit?rev=2394ccc#2394ccc53e69de5f59b62da5386096050e307649"
+source = "git+https://github.com/cedoor/bristol-circuit?rev=ff7587a#ff7587a4785baaa454498479839dd954424c13ea"
 dependencies = [
  "serde",
  "serde_json",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,5 +14,5 @@ url = "2.2.1"
 serde = "1.0"
 serde_qs = "0.8.0"
 serde_json = "1.0"
-bristol-circuit = { git = "https://github.com/voltrevo/bristol-circuit", rev = "2394ccc" }
-boolify = { git = "https://github.com/voltrevo/boolify", rev = "8766836" }
+bristol-circuit = { git = "https://github.com/cedoor/bristol-circuit", rev = "ff7587a" }
+boolify = { git = "https://github.com/voltrevo/boolify", rev = "eaabb17" }

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -13,4 +13,4 @@ num-bigint = "0.4"
 num-traits = "0.2"
 serde = "1.0"
 serde_json = "1.0"
-bristol-circuit = { git = "https://github.com/voltrevo/bristol-circuit", rev = "2394ccc" }
+bristol-circuit = { git = "https://github.com/cedoor/bristol-circuit", rev = "ff7587a" }

--- a/compiler/src/circuit.rs
+++ b/compiler/src/circuit.rs
@@ -1,4 +1,4 @@
-use std::{cmp::max, collections::HashMap};
+use std::{cmp::max, collections::BTreeMap};
 
 use bristol_circuit::{BristolCircuit, CircuitInfo, ConstantInfo, Gate as BristolGate};
 use valuescript_vm::{binary_op::BinaryOp, unary_op::UnaryOp};
@@ -8,9 +8,9 @@ use crate::bristol_op_strings::{to_bristol_binary_op, to_bristol_unary_op};
 #[derive(Default)]
 pub struct Circuit {
   pub size: usize,
-  pub inputs: HashMap<String, usize>,
-  pub constants: HashMap<usize, usize>, // wire_id -> value
-  pub outputs: HashMap<String, usize>,
+  pub inputs: BTreeMap<String, usize>,
+  pub constants: BTreeMap<usize, usize>, // wire_id -> value
+  pub outputs: BTreeMap<String, usize>,
   pub gates: Vec<Gate>,
 }
 
@@ -29,7 +29,7 @@ pub enum Gate {
 }
 
 impl Circuit {
-  pub fn eval<N: CircuitNumber>(&self, inputs: &HashMap<String, N>) -> HashMap<String, N> {
+  pub fn eval<N: CircuitNumber>(&self, inputs: &BTreeMap<String, N>) -> BTreeMap<String, N> {
     let mut wire_values = vec![N::zero(); self.size];
 
     for (name, wire_id) in &self.inputs {
@@ -55,7 +55,7 @@ impl Circuit {
       }
     }
 
-    let mut res = HashMap::<String, N>::new();
+    let mut res = BTreeMap::<String, N>::new();
 
     for (name, wire_id) in &self.outputs {
       res.insert(name.clone(), wire_values[*wire_id].clone());
@@ -111,13 +111,13 @@ impl Circuit {
       });
     }
 
-    let input_name_to_wire_index: HashMap<String, usize> = self
+    let input_name_to_wire_index: BTreeMap<String, usize> = self
       .inputs
       .iter()
       .map(|(name, id)| (name.clone(), *id))
       .collect();
 
-    let constants: HashMap<String, ConstantInfo> = self
+    let constants: BTreeMap<String, ConstantInfo> = self
       .constants
       .iter()
       .map(|(id, value)| {
@@ -131,7 +131,7 @@ impl Circuit {
       })
       .collect();
 
-    let output_name_to_wire_index: HashMap<String, usize> = self
+    let output_name_to_wire_index: BTreeMap<String, usize> = self
       .outputs
       .iter()
       .map(|(name, id)| (name.clone(), *id))

--- a/compiler/src/compile.rs
+++ b/compiler/src/compile.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashMap, rc::Rc};
+use std::{cell::RefCell, collections::BTreeMap, collections::HashMap, rc::Rc};
 
 use valuescript_compiler::{asm, assemble, Diagnostic, ResolvedPath};
 use valuescript_vm::vs_value::{ToDynamicVal, Val, VsType};
@@ -161,17 +161,17 @@ fn generate_circuit(
   output_ids: Vec<usize>,
   builder: CircuitBuilder,
 ) -> Circuit {
-  let mut inputs = HashMap::<String, usize>::new();
+  let mut inputs = BTreeMap::<String, usize>::new();
   for (i, reg) in fn_.parameters.iter().enumerate() {
     inputs.insert(reg.name.clone(), i);
   }
 
-  let mut constants = HashMap::<usize, usize>::new();
+  let mut constants = BTreeMap::<usize, usize>::new();
   for (value, wire_id) in &builder.constants {
     constants.insert(*wire_id, *value);
   }
 
-  let mut outputs = HashMap::<String, usize>::new();
+  let mut outputs = BTreeMap::<String, usize>::new();
   if output_ids.len() == 1 {
     outputs.insert(name, output_ids[0]);
   } else {

--- a/compiler/src/tests.rs
+++ b/compiler/src/tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests_ {
-  use std::{collections::HashMap, fs, path::PathBuf};
+  use std::{collections::BTreeMap, fs, path::PathBuf};
 
   use crate::{compile, resolve_entry_path::resolve_entry_path, CompileOk};
 
@@ -28,7 +28,7 @@ mod tests_ {
         .inputs
         .iter()
         .map(|(name, i)| (name.clone(), input[*i]))
-        .collect::<HashMap<_, _>>();
+        .collect::<BTreeMap<_, _>>();
 
       let outputs = circuit.eval(&inputs);
 
@@ -39,7 +39,7 @@ mod tests_ {
         .iter()
         .enumerate()
         .map(|(i, (name, _))| ((*name).clone(), i))
-        .collect::<HashMap<_, _>>();
+        .collect::<BTreeMap<_, _>>();
 
       for (name, value) in &outputs {
         let wire_id = output_name_to_index[name];


### PR DESCRIPTION
## What is this PR doing?

`HashMap` does not preserve any particular order because its internal structure is based on hashing. However, the keys in the circuit fields should always have the same order since they could be used with hashes for integrity checks etc. Instead, `BTreeMap` has been used, which preserves the order of the keys.

See voltrevo/emp-wasm-backend#7 for information about this issue.

After this PR is merged, it's necessary to update the following dependencies: [bristol-circuit](https://github.com/voltrevo/bristol-circuit) and [boolify](https://github.com/voltrevo/boolify), which have been temporarily changed for testing.

## How can these changes be manually tested?

Run `cargo test`. This change doesn't change the behavior of the lib. 

## Does this PR resolve or contribute to any issues?

No.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
