### PR TITLE
Fix recursive inclusion

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
         "args": [
           "build",
           "--bin=summonc",
-          "--package=cli"
+          "--package=summon_cli"
         ],
         "filter": {
           "name": "summonc",
@@ -20,7 +20,7 @@
         }
       },
       "args": [
-        "examples/nthPrime.ts"
+        "foo.ts"
       ],
       "cwd": "${workspaceFolder}"
     },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 [[package]]
 name = "boolify"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/boolify?rev=f68ee3a#f68ee3a66e8c762dabda5be4bbe1f328d2b8fdd8"
+source = "git+https://github.com/voltrevo/boolify?rev=cec0efa#cec0efa7ad938da96078e9e2a65a741b1417918a"
 dependencies = [
  "bristol-circuit",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,4 +14,4 @@ serde = "1.0"
 serde_qs = "0.8.0"
 serde_json = "1.0"
 bristol-circuit = { git = "https://github.com/voltrevo/bristol-circuit", rev = "288847c" }
-boolify = { git = "https://github.com/voltrevo/boolify", rev = "f68ee3a" }
+boolify = { git = "https://github.com/voltrevo/boolify", rev = "cec0efa" }

--- a/compiler/src/compile.rs
+++ b/compiler/src/compile.rs
@@ -182,6 +182,9 @@ fn build(input_len: usize, outputs: Vec<Val>) -> (Vec<usize>, CircuitBuilder) {
   builder.include_inputs(input_len);
   let output_ids = builder.include_outputs(&outputs);
 
+  drop(outputs);
+  builder.drop_signal_data();
+
   (output_ids, builder)
 }
 

--- a/vm/src/circuit.rs
+++ b/vm/src/circuit.rs
@@ -1,12 +1,11 @@
 use std::{cmp::max, collections::BTreeMap};
 
-use bristol_circuit::{BristolCircuit, CircuitInfo, ConstantInfo, Gate as BristolGate};
 use crate::{binary_op::BinaryOp, unary_op::UnaryOp};
+use bristol_circuit::{BristolCircuit, CircuitInfo, ConstantInfo, Gate as BristolGate};
 
 use crate::bristol_op_strings::{to_bristol_binary_op, to_bristol_unary_op};
 
-#[derive(Default)]
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct Circuit {
   pub size: usize,
   pub inputs: BTreeMap<String, usize>,

--- a/vm/src/circuit_builder.rs
+++ b/vm/src/circuit_builder.rs
@@ -179,7 +179,7 @@ impl CircuitBuilder {
           .map(|dep| self.include_val_shallow(dep))
           .collect::<Vec<usize>>();
 
-        self.include_signal_shallow(signal, dependent_ids);
+        self.include_signal_shallow(leaf_signal, dependent_ids);
 
         for parent_signal in signal_id_to_parent_signals
           .get(&leaf_signal.id)

--- a/vm/src/circuit_builder.rs
+++ b/vm/src/circuit_builder.rs
@@ -1,7 +1,10 @@
-use std::collections::HashMap;
+use std::{
+  collections::{BTreeMap, HashMap, HashSet},
+  mem::swap,
+};
 
-use num_traits::ToPrimitive;
 use crate::{vs_value::Val, ValTrait};
+use num_traits::ToPrimitive;
 
 use crate::{
   circuit::Gate,
@@ -42,6 +45,14 @@ impl CircuitBuilder {
   }
 
   pub fn include_val(&mut self, val: &Val) -> usize {
+    if let Some(signal) = as_circuit_signal(val) {
+      return self.include_signal(signal);
+    }
+
+    self.include_val_shallow(val)
+  }
+
+  pub fn include_val_shallow(&mut self, val: &Val) -> usize {
     match val {
       Val::Bool(bool) => {
         let value = if *bool { 1usize } else { 0usize };
@@ -78,39 +89,10 @@ impl CircuitBuilder {
         wire_id
       }
       Val::Dynamic(dyn_val) => {
-        if let Some(circuit_number) = dyn_val.as_any().downcast_ref::<CircuitSignal>() {
-          if let Some(wire_id) = self.wires_included.get(&circuit_number.id) {
+        if let Some(signal) = dyn_val.as_any().downcast_ref::<CircuitSignal>() {
+          if let Some(wire_id) = self.wires_included.get(&signal.id) {
             return *wire_id;
           }
-
-          let dependent_ids = get_dependencies(val)
-            .iter()
-            .map(|dep| self.include_val(dep))
-            .collect::<Vec<usize>>();
-
-          let wire_id = self.wire_count;
-          self.wire_count += 1;
-
-          let gate = match &circuit_number.data {
-            CircuitSignalData::Input => panic!("Input should have been included earlier"),
-            CircuitSignalData::UnaryOp(op, _) => Gate::Unary {
-              op: *op,
-              input: dependent_ids[0],
-              output: wire_id,
-            },
-            CircuitSignalData::BinaryOp(op, _, _) => Gate::Binary {
-              op: *op,
-              left: dependent_ids[0],
-              right: dependent_ids[1],
-              output: wire_id,
-            },
-          };
-
-          self.gates.push(gate);
-
-          self.wires_included.insert(circuit_number.id, wire_id);
-
-          return wire_id;
         }
 
         panic!("Can't include unrecognized type ({}) 1", val.codify());
@@ -118,22 +100,144 @@ impl CircuitBuilder {
       _ => panic!("Can't include unrecognized type ({}) 2", val.codify()),
     }
   }
+
+  pub fn include_signal_shallow(
+    &mut self,
+    signal: &CircuitSignal,
+    dependent_ids: Vec<usize>,
+  ) -> usize {
+    let wire_id = self.wire_count;
+    self.wire_count += 1;
+
+    let gate = match &signal.data {
+      CircuitSignalData::Input => panic!("Input should have been included earlier"),
+      CircuitSignalData::UnaryOp(op, _) => Gate::Unary {
+        op: *op,
+        input: dependent_ids[0],
+        output: wire_id,
+      },
+      CircuitSignalData::BinaryOp(op, _, _) => Gate::Binary {
+        op: *op,
+        left: dependent_ids[0],
+        right: dependent_ids[1],
+        output: wire_id,
+      },
+    };
+
+    self.gates.push(gate);
+
+    self.wires_included.insert(signal.id, wire_id);
+
+    wire_id
+  }
+
+  pub fn include_signal(&mut self, signal: &CircuitSignal) -> usize {
+    if let Some(wire_id) = self.wires_included.get(&signal.id) {
+      return *wire_id;
+    }
+
+    let mut signals_to_process = vec![signal.clone()];
+    let mut signal_id_to_parent_signals = HashMap::<usize, Vec<CircuitSignal>>::new();
+    let mut signal_id_to_dep_ids = HashMap::<usize, HashSet<usize>>::new();
+    let mut id_to_leaf_signal = BTreeMap::<usize, CircuitSignal>::new();
+
+    while let Some(signal) = signals_to_process.pop() {
+      let mut dep_ids = HashSet::<usize>::new();
+
+      for dep in get_signal_dependencies(&signal) {
+        let Some(dep_signal) = as_circuit_signal(&dep) else {
+          continue;
+        };
+
+        if self.wires_included.contains_key(&dep_signal.id) {
+          continue;
+        }
+
+        dep_ids.insert(dep_signal.id);
+
+        signal_id_to_parent_signals
+          .entry(dep_signal.id)
+          .or_default()
+          .push(signal.clone());
+
+        signals_to_process.push(dep_signal.clone());
+      }
+
+      if dep_ids.is_empty() {
+        id_to_leaf_signal.insert(signal.id, signal.clone());
+      } else {
+        signal_id_to_dep_ids.insert(signal.id, dep_ids);
+      }
+    }
+
+    let mut next_id_to_leaf_signal = BTreeMap::<usize, CircuitSignal>::new();
+
+    loop {
+      for (_, leaf_signal) in id_to_leaf_signal.iter() {
+        let dependent_ids = get_signal_dependencies(leaf_signal)
+          .iter()
+          .map(|dep| self.include_val_shallow(dep))
+          .collect::<Vec<usize>>();
+
+        self.include_signal_shallow(signal, dependent_ids);
+
+        for parent_signal in signal_id_to_parent_signals
+          .get(&leaf_signal.id)
+          .unwrap_or(&vec![])
+        {
+          let dep_ids = signal_id_to_dep_ids.get_mut(&parent_signal.id).unwrap();
+          dep_ids.remove(&leaf_signal.id);
+
+          if dep_ids.is_empty() {
+            next_id_to_leaf_signal.insert(parent_signal.id, parent_signal.clone());
+          }
+        }
+      }
+
+      if next_id_to_leaf_signal.is_empty() {
+        break;
+      }
+
+      id_to_leaf_signal.clear();
+      swap(&mut id_to_leaf_signal, &mut next_id_to_leaf_signal);
+    }
+
+    if let Some(wire_id) = self.wires_included.get(&signal.id) {
+      return *wire_id;
+    }
+
+    panic!("Failed to include signal");
+  }
 }
 
 fn get_dependencies(val: &Val) -> Vec<Val> {
   if let Val::Dynamic(val) = val {
     if let Some(circuit_number) = val.as_any().downcast_ref::<CircuitSignal>() {
-      return match &circuit_number.data {
-        CircuitSignalData::Input => vec![],
-        CircuitSignalData::UnaryOp(_, input) => {
-          vec![input.clone()]
-        }
-        CircuitSignalData::BinaryOp(_, left, right) => {
-          vec![left.clone(), right.clone()]
-        }
-      };
+      return get_signal_dependencies(circuit_number);
     }
   }
 
   vec![]
+}
+
+fn as_circuit_signal(val: &Val) -> Option<&CircuitSignal> {
+  if let Val::Dynamic(val) = val {
+    if let Some(signal) = val.as_any().downcast_ref::<CircuitSignal>() {
+      return Some(signal);
+    }
+  }
+
+  None
+}
+
+fn get_signal_dependencies(signal: &CircuitSignal) -> Vec<Val> {
+  match &signal.data {
+    CircuitSignalData::Input => vec![],
+    CircuitSignalData::UnaryOp(_, input) => {
+      vec![input.clone()]
+    }
+    CircuitSignalData::BinaryOp(_, left, right) => {
+      vec![left.clone(), right.clone()]
+    }
+  }
 }

--- a/vm/src/circuit_builder.rs
+++ b/vm/src/circuit_builder.rs
@@ -137,11 +137,18 @@ impl CircuitBuilder {
     }
 
     let mut signals_to_process = vec![signal.clone()];
+    let mut signals_ids_processed = HashSet::<usize>::new();
     let mut signal_id_to_parent_signals = HashMap::<usize, Vec<CircuitSignal>>::new();
     let mut signal_id_to_dep_ids = HashMap::<usize, HashSet<usize>>::new();
     let mut id_to_leaf_signal = BTreeMap::<usize, CircuitSignal>::new();
 
     while let Some(signal) = signals_to_process.pop() {
+      if signals_ids_processed.contains(&signal.id) {
+        continue;
+      }
+
+      signals_ids_processed.insert(signal.id);
+
       let mut dep_ids = HashSet::<usize>::new();
 
       for dep in get_signal_dependencies(&signal) {
@@ -202,11 +209,11 @@ impl CircuitBuilder {
       swap(&mut id_to_leaf_signal, &mut next_id_to_leaf_signal);
     }
 
-    if let Some(wire_id) = self.wires_included.get(&signal.id) {
-      return *wire_id;
-    }
+    let Some(wire_id) = self.wires_included.get(&signal.id) else {
+      panic!("Failed to include signal");
+    };
 
-    panic!("Failed to include signal");
+    *wire_id
   }
 }
 


### PR DESCRIPTION
## What is this PR doing?

Similar to https://github.com/voltrevo/boolify/pull/7 but for this repo.

- Uses updated version of boolify with recursion fixes
- Strategically drops outputs and signal data to avoid recursive dropping
- Makes circuit_builder iterative to avoid stack overflow due to recursive inclusion

## How can these changes be manually tested?

Compile a really deep circuit like this one:

```ts
const ITER = 100_000;

export default function main(x: number) {
  let fa = x;
  let fb = 0;

  for (let i = 0; i < ITER; i++) {
    [fa, fb] = [fb, (fa + fb)];
  }

  return fb;
}
```

## Does this PR resolve or contribute to any issues?

Resolves https://www.notion.so/pse-team/Fix-summon-stack-overflow-196d57e8dd7e80bca257ddcd16ab5b18?pvs=4

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
