### PR TITLE
Add summon builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Summon
 
-*A language for collaboratively summoning computations.*
+_A language for collaboratively summoning computations._
 
 Based on [ValueScript](https://github.com/voltrevo/ValueScript).
 
@@ -17,15 +17,20 @@ export PATH="$PATH:$PWD/target/debug"
 summonc main.ts
 ```
 
-This will generate the circuit in [bristol format](https://nigelsmart.github.io/MPC-Circuits/) at `output/circuit.txt` and a description of the inputs, outputs, and constants at `output/circuit_info.json`.
+This will generate the circuit in
+[bristol format](https://nigelsmart.github.io/MPC-Circuits/) at
+`output/circuit.txt` and a description of the inputs, outputs, and constants at
+`output/circuit_info.json`.
 
-You can also produce boolean circuits by adding `--boolify-width 16`. (See [boolify](https://github.com/voltrevo/boolify) for more about boolean circuits.)
+You can also produce boolean circuits by adding `--boolify-width 16`. (See
+[boolify](https://github.com/voltrevo/boolify) for more about boolean circuits.)
 
 ### NodeJS
 
 Runs via WebAssembly so you don't need a rust environment on your system.
 
-See [`@mpc-cli/summon`](https://github.com/cedoor/mpc-cli/tree/main/packages/cli-summon).
+See
+[`@mpc-cli/summon`](https://github.com/cedoor/mpc-cli/tree/main/packages/cli-summon).
 
 ```sh
 npx @mpc-cli/summon main.ts
@@ -38,7 +43,8 @@ npm i -g @mpc-cli/summon
 summonc main.ts
 ```
 
-There is also a NodeJS API: [`summon-ts`](https://github.com/voltrevo/summon-ts).
+There is also a NodeJS API:
+[`summon-ts`](https://github.com/voltrevo/summon-ts).
 
 ## Example
 
@@ -89,9 +95,10 @@ summonc examples/loopAdd.ts
 
 ## Signal-Dependent Branching
 
-Building a circuit from a program with a fixed path is relatively straightforward. The real power
-of Summon is its ability to handle signal-dependent branches - where the program follows a
-different path depending on the input. For example:
+Building a circuit from a program with a fixed path is relatively
+straightforward. The real power of Summon is its ability to handle
+signal-dependent branches - where the program follows a different path depending
+on the input. For example:
 
 ```ts
 // examples/greaterThan10.ts
@@ -110,18 +117,21 @@ export default function main(x: number) {
 2 1 2 1 3 AMul
 ```
 
-Above, the constant 10 is used for wire 1, so the circuit is `output = (x > 10) * 10`.
+Above, the constant 10 is used for wire 1, so the circuit is
+`output = (x > 10) * 10`.
 
-Summon can also handle more complex branching, so you can use loops and even things like
-`continue`, `break`, and `switch`. You can also conditionally throw exceptions as long as you
-catch them.
+Summon can also handle more complex branching, so you can use loops and even
+things like `continue`, `break`, and `switch`. You can also conditionally throw
+exceptions as long as you catch them.
 
-To achieve this, Summon has a general solution to handle any conditional jump instruction.
-A conditional jump generates a new evaluation branch, and each branch tracks a multiplier signal.
-Summon dynamically manages these branches and merges them when they reach the same location.
+To achieve this, Summon has a general solution to handle any conditional jump
+instruction. A conditional jump generates a new evaluation branch, and each
+branch tracks a multiplier signal. Summon dynamically manages these branches and
+merges them when they reach the same location.
 
-However, it is easy to write programs which branch indefinitely and never consolidate into a single
-fixed circuit. Programs like this become infinite loops:
+However, it is easy to write programs which branch indefinitely and never
+consolidate into a single fixed circuit. Programs like this become infinite
+loops:
 
 ```ts
 for (let i = 0; i < input; i++) {
@@ -129,9 +139,10 @@ for (let i = 0; i < input; i++) {
 }
 ```
 
-A traditional runtime can terminate shortly after `i` reaches `input`, but because `input` isn't
-known during compilation, Summon will get stuck in a loop as it adds more and more circuitry
-to handle larger and larger values of `input` forever.
+A traditional runtime can terminate shortly after `i` reaches `input`, but
+because `input` isn't known during compilation, Summon will get stuck in a loop
+as it adds more and more circuitry to handle larger and larger values of `input`
+forever.
 
 ## Limitations
 
@@ -142,8 +153,9 @@ to handle larger and larger values of `input` forever.
 
 ## Exercises
 
-If you'd like to try your hand at Summon but you're not sure where to start, I have prepared
-some exercises you might find interesting:
+If you'd like to try your hand at Summon but you're not sure where to start, I
+have prepared some exercises you might find interesting:
+
 - [Check Supermajority](./examples/exercises/checkSuperMajority.ts)
 - [Approval Voting](./examples/exercises/approvalVoting.ts)
 - TODO: exercise with in-between difficulty
@@ -153,6 +165,15 @@ some exercises you might find interesting:
 
 [Solutions](https://github.com/voltrevo/summon/tree/exercise-solutions/examples/exerciseSolutions).
 
+## `summon` APIs
+
+In Summon you have access to a special global called `summon`. If you're running
+TypeScript, you can copy `summon.d.ts` into your project to get accurate type
+information.
+
 ## Why "Summon"
 
-The circuits generated by Summon are intended for MPC. When performing MPC, you use cryptography to collaboratively compute the output of a function without anyone seeing each other's inputs or any of the intermediary calculations. It's like *summoning* the result with magic.
+The circuits generated by Summon are intended for MPC. When performing MPC, you
+use cryptography to collaboratively compute the output of a function without
+anyone seeing each other's inputs or any of the intermediary calculations. It's
+like _summoning_ the result with magic.

--- a/common/src/builtins.rs
+++ b/common/src/builtins.rs
@@ -34,6 +34,9 @@ pub enum BuiltinName {
 
   #[allow(non_camel_case_types)]
   console,
+
+  #[allow(non_camel_case_types)]
+  summon,
 }
 
 pub const BUILTIN_NAMES: [&str; BuiltinName::COUNT] = [
@@ -55,6 +58,7 @@ pub const BUILTIN_NAMES: [&str; BuiltinName::COUNT] = [
   "SymbolIterator",
   "BigInt",
   "console",
+  "summon",
 ];
 
 pub const BUILTIN_COUNT: usize = BuiltinName::COUNT;

--- a/examples/isSignalTest.ts
+++ b/examples/isSignalTest.ts
@@ -1,0 +1,28 @@
+//! test [1] => [2]
+
+export default (x: number) => {
+  let count = 0;
+
+  if (summon.isSignal('hello')) {
+    count++;
+  }
+  // 'hello' is not a signal, count: 0
+
+  if (summon.isSignal(count)) {
+    count++;
+  }
+  // `count` is not a signal, count: 0
+
+  if (summon.isSignal(x)) {
+    count += x;
+  }
+  // `x` is a signal, count: x
+
+  if (summon.isSignal(count)) {
+    count++;
+  }
+  // `count` is a signal, count: x + 1
+  // (even though it wasn't before)
+
+  return count;
+};

--- a/summon.d.ts
+++ b/summon.d.ts
@@ -1,0 +1,3 @@
+declare const summon: {
+  isSignal(value: unknown): boolean;
+};

--- a/vm/src/builtins/mod.rs
+++ b/vm/src/builtins/mod.rs
@@ -10,9 +10,11 @@ mod math_builtin;
 mod number_builtin;
 pub mod range_error_builtin;
 mod string_builtin;
+mod summon_builtin;
 mod symbol_builtin;
 pub mod type_error_builtin;
 
+use summon_builtin::SummonBuiltin;
 use summon_common::BUILTIN_COUNT;
 
 use crate::{
@@ -48,4 +50,5 @@ pub static BUILTIN_VALS: [fn() -> Val; BUILTIN_COUNT] = [
   || VsSymbol::ITERATOR.to_val(),
   || BigIntBuiltin {}.to_val(),
   || ConsoleBuiltin {}.to_val(),
+  || SummonBuiltin {}.to_val(),
 ];

--- a/vm/src/builtins/summon_builtin.rs
+++ b/vm/src/builtins/summon_builtin.rs
@@ -1,0 +1,40 @@
+use std::fmt;
+use std::rc::Rc;
+
+use crate::native_function::{native_fn, NativeFunction};
+use crate::vs_class::VsClass;
+use crate::vs_value::{LoadFunctionResult, ToVal, Val};
+
+use super::builtin_object::BuiltinObject;
+
+pub struct SummonBuiltin {}
+
+impl BuiltinObject for SummonBuiltin {
+  fn bo_name() -> &'static str {
+    "summon"
+  }
+
+  fn bo_sub(key: &str) -> Val {
+    match key {
+      "isSignal" => IS_SIGNAL.to_val(),
+
+      _ => Val::Undefined,
+    }
+  }
+
+  fn bo_load_function() -> LoadFunctionResult {
+    LoadFunctionResult::NotAFunction
+  }
+
+  fn bo_as_class_data() -> Option<Rc<VsClass>> {
+    None
+  }
+}
+
+impl fmt::Display for SummonBuiltin {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "[object summon]")
+  }
+}
+
+static IS_SIGNAL: NativeFunction = native_fn(|_this, params| Ok(Val::Bool(true)));

--- a/vm/src/builtins/summon_builtin.rs
+++ b/vm/src/builtins/summon_builtin.rs
@@ -1,7 +1,9 @@
 use std::fmt;
 use std::rc::Rc;
 
+use crate::circuit_signal::CircuitSignal;
 use crate::native_function::{native_fn, NativeFunction};
+use crate::val_dynamic_downcast::val_dynamic_downcast;
 use crate::vs_class::VsClass;
 use crate::vs_value::{LoadFunctionResult, ToVal, Val};
 
@@ -37,4 +39,10 @@ impl fmt::Display for SummonBuiltin {
   }
 }
 
-static IS_SIGNAL: NativeFunction = native_fn(|_this, params| Ok(Val::Bool(true)));
+static IS_SIGNAL: NativeFunction = native_fn(|_this, params| {
+  let Some(x) = params.first() else {
+    return Ok(false.to_val());
+  };
+
+  Ok(val_dynamic_downcast::<CircuitSignal>(x).is_some().to_val())
+});


### PR DESCRIPTION
## What is this PR doing?

Adds summon builtin with a sample function `summon.isSignal(x)`, returning whether x is a signal.

Based on similar changes @cedoor originally [prototyped in ValueScript](https://github.com/cedoor/ValueScript/commit/66b6d3d) 🥲.

## How can these changes be manually tested?

`cargo test` (see examples/isSignalTest.ts)

## Does this PR resolve or contribute to any issues?

Resolves https://www.notion.so/pse-team/Create-new-Summon-builtin-191d57e8dd7e8054a841c8c2e6050414?pvs=4

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
