### PR TITLE
Bool io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 [[package]]
 name = "boolify"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/boolify?rev=346d090#346d090a132ec63550ee912d6f86ac41a0586e63"
+source = "git+https://github.com/voltrevo/boolify?rev=ef84823#ef84823ef13b959dc829f2d789b24b0d5797b639"
 dependencies = [
  "bristol-circuit",
  "serde",
@@ -175,7 +175,7 @@ dependencies = [
 [[package]]
 name = "bristol-circuit"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/bristol-circuit?rev=063d73a#063d73a2fc66167ff8b17ee0acd59cff53913555"
+source = "git+https://github.com/voltrevo/bristol-circuit?rev=10ee9c7#10ee9c7c07d3cfdd7163b4c8ebf529a72c1006bb"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 [[package]]
 name = "boolify"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/boolify?rev=09a5636#09a5636fffef8025eaf4f847dacb16e886853d6a"
+source = "git+https://github.com/voltrevo/boolify?rev=346d090#346d090a132ec63550ee912d6f86ac41a0586e63"
 dependencies = [
  "bristol-circuit",
  "serde",
@@ -175,7 +175,7 @@ dependencies = [
 [[package]]
 name = "bristol-circuit"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/bristol-circuit?rev=288847c#288847cdf8391627eeaaf2adea8971f944ea055f"
+source = "git+https://github.com/voltrevo/bristol-circuit?rev=063d73a#063d73a2fc66167ff8b17ee0acd59cff53913555"
 dependencies = [
  "serde",
  "serde_json",
@@ -1380,6 +1380,7 @@ dependencies = [
 name = "summon_common"
 version = "0.1.0"
 dependencies = [
+ "serde_json",
  "strum",
  "strum_macros",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ resolver = "2"
 
 [workspace.dependencies]
 bincode = "2"
-boolify = { git = "https://github.com/voltrevo/boolify", rev = "09a5636" }
-bristol-circuit = { git = "https://github.com/voltrevo/bristol-circuit", rev = "288847c" }
+boolify = { git = "https://github.com/voltrevo/boolify", rev = "346d090" }
+bristol-circuit = { git = "https://github.com/voltrevo/bristol-circuit", rev = "063d73a" }
 num-bigint = "0.4"
 num-derive = "0.4"
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ resolver = "2"
 
 [workspace.dependencies]
 bincode = "2"
-boolify = { git = "https://github.com/voltrevo/boolify", rev = "346d090" }
-bristol-circuit = { git = "https://github.com/voltrevo/bristol-circuit", rev = "063d73a" }
+boolify = { git = "https://github.com/voltrevo/boolify", rev = "ef84823" }
+bristol-circuit = { git = "https://github.com/voltrevo/bristol-circuit", rev = "10ee9c7" }
 num-bigint = "0.4"
 num-derive = "0.4"
 num-traits = "0.2"

--- a/README.md
+++ b/README.md
@@ -85,13 +85,23 @@ summonc examples/loopAdd.ts
 // output/circuit_info.json
 
 {
-  "input_name_to_wire_index": {
-    "input": 0
-  },
-  "constants": {},
-  "output_name_to_wire_index": {
-    "main": 2
-  }
+  "constants": [],
+  "inputs": [
+    {
+      "name": "input",
+      "type": "number",
+      "address": 0,
+      "width": 1
+    }
+  ],
+  "outputs": [
+    {
+      "name": "res",
+      "type": "number",
+      "address": 2,
+      "width": 1
+    }
+  ]
 }
 ```
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -41,12 +41,12 @@ fn main() {
   let public_inputs: HashMap<String, Val> = if let Some(path) = public_inputs_path {
     if path.get(0..1) == Some("{") {
       // if the first character is '{', we assume it's a json string
-      let numbers = serde_json::from_str::<HashMap<String, usize>>(&path)
+      let numbers = serde_json::from_str::<HashMap<String, serde_json::Value>>(&path)
         .expect("Failed to parse public inputs string");
 
       numbers
         .into_iter()
-        .map(|(k, v)| (k, Val::Number(v as f64)))
+        .map(|(k, v)| (k, Val::from_json(&v)))
         .collect::<HashMap<_, _>>()
     } else {
       let path = Path::new(&path);
@@ -59,12 +59,12 @@ fn main() {
       let file = File::open(path).expect("Failed to open public inputs file");
 
       // only numbers for now
-      let numbers = serde_json::from_reader::<_, HashMap<String, usize>>(file)
+      let numbers = serde_json::from_reader::<_, HashMap<String, serde_json::Value>>(file)
         .expect("Failed to parse public inputs file");
 
       numbers
         .into_iter()
-        .map(|(k, v)| (k, Val::Number(v as f64)))
+        .map(|(k, v)| (k, Val::from_json(&v)))
         .collect::<HashMap<_, _>>()
     }
   } else {

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 strum = { workspace = true }
 strum_macros = { workspace = true }
+serde_json = { workspace = true }

--- a/common/src/utils.rs
+++ b/common/src/utils.rs
@@ -59,5 +59,6 @@ pub fn code_point_at(bytes: &[u8], len: usize, index: usize) -> Option<u32> {
 pub struct InputDescriptor {
   pub from: String,
   pub name: String,
+  pub type_json: serde_json::Value,
   pub id: usize,
 }

--- a/compiler/src/compile.rs
+++ b/compiler/src/compile.rs
@@ -4,7 +4,7 @@ use std::{cell::RefCell, collections::BTreeMap, collections::HashMap, rc::Rc};
 use crate::asm::Module;
 use crate::summon_io::SummonIO;
 use summon_common::InputDescriptor;
-use summon_vm::circuit::MpcSettings;
+use summon_vm::circuit::{CircuitInput, MpcSettings};
 use summon_vm::vs_value::{ToDynamicVal, Val};
 use summon_vm::{
   circuit::Circuit, circuit_builder::CircuitBuilder, circuit_vm::CircuitVM,
@@ -256,14 +256,20 @@ fn generate_circuit(
   outputs: BTreeMap<String, usize>,
   builder: CircuitBuilder,
 ) -> Circuit {
-  let mut inputs = BTreeMap::<String, usize>::new();
+  let mut inputs = BTreeMap::<String, CircuitInput>::new();
   for (i, desc) in input_descriptors.iter().enumerate() {
-    inputs.insert(desc.name.clone(), i);
+    inputs.insert(
+      desc.name.clone(),
+      CircuitInput {
+        wire_id: i,
+        type_json: desc.type_json.clone(),
+      },
+    );
   }
 
-  let mut constants = BTreeMap::<usize, usize>::new();
+  let mut constants = BTreeMap::<usize, serde_json::Value>::new();
   for (value, wire_id) in &builder.constants {
-    constants.insert(*wire_id, *value);
+    constants.insert(*wire_id, value.clone());
   }
 
   let outputs_vec = outputs.keys().cloned().collect::<Vec<_>>();

--- a/compiler/src/summon_io.rs
+++ b/compiler/src/summon_io.rs
@@ -313,8 +313,8 @@ static OUTPUT: NativeFunction = native_fn(|this, params| {
     return Err("Expected `name` to be a string".to_type_error());
   };
 
-  if value.typeof_() != VsType::Number {
-    return Err("Non-number outputs are not yet supported".to_type_error());
+  if value.typeof_() != VsType::Number && value.typeof_() != VsType::Bool {
+    return Err("Only number and bool outputs are currently supported".to_type_error());
   }
 
   // _io_data.add_party(to.to_string());
@@ -343,8 +343,8 @@ static OUTPUT_PUBLIC: NativeFunction = native_fn(|this, params| {
     return Err("Expected name to be a string".to_type_error());
   };
 
-  if value.typeof_() != VsType::Number {
-    return Err("Non-number outputs are not yet supported".to_type_error());
+  if value.typeof_() != VsType::Number && value.typeof_() != VsType::Bool {
+    return Err("Only number and bool outputs are currently supported".to_type_error());
   }
 
   if io_data

--- a/compiler/src/tests.rs
+++ b/compiler/src/tests.rs
@@ -7,7 +7,7 @@ mod tests_ {
   };
 
   use summon_vm::{
-    circuit::CircuitInput,
+    circuit::{CircuitInput, CircuitNumber, NumberOrBool},
     vs_value::{ToVal, Val},
   };
 
@@ -53,7 +53,7 @@ mod tests_ {
               wire_id,
               type_json: _,
             },
-          )| (name.clone(), input[*wire_id]),
+          )| { (name.clone(), NumberOrBool::from_json(&input[*wire_id])) },
         )
         .collect::<BTreeMap<_, _>>();
 
@@ -78,7 +78,7 @@ mod tests_ {
 
         assert_eq!(
           *value,
-          expected_output[wire_id],
+          NumberOrBool::from_json(&expected_output[wire_id]),
           "Test: {}: {}: Output mismatch for {}: expected {}, got {} ({:?} vs {:?})",
           path.path,
           descriptor,
@@ -97,8 +97,8 @@ mod tests_ {
     path: String,
     descriptor: String,
     public_inputs: HashMap<String, Val>,
-    input: Vec<usize>,
-    expected_output: Vec<usize>,
+    input: Vec<serde_json::Value>,
+    expected_output: Vec<serde_json::Value>,
   }
 
   fn parse_test_case(path: &str, line: &str) -> Option<TestCase> {
@@ -151,15 +151,15 @@ mod tests_ {
     );
 
     // parse input vector
-    let input = parts[0]
+    let input: Vec<serde_json::Value> = parts[0]
       .trim()
       .trim_start_matches('[')
       .trim_end_matches(']')
       .split(',')
       .map(|s| {
         let t = s.trim();
-        t.parse::<usize>()
-          .unwrap_or_else(|_| panic!("invalid usize `{}` in input array", t))
+        serde_json::from_str::<serde_json::Value>(t)
+          .unwrap_or_else(|_| panic!("invalid JSON `{}` in input array", t))
       })
       .collect();
 
@@ -171,8 +171,8 @@ mod tests_ {
       .split(',')
       .map(|s| {
         let t = s.trim();
-        t.parse::<usize>()
-          .unwrap_or_else(|_| panic!("invalid usize `{}` in expected_output array", t))
+        serde_json::from_str::<serde_json::Value>(t)
+          .unwrap_or_else(|_| panic!("invalid JSON `{}` in expected_output array", t))
       })
       .collect();
 

--- a/compiler/src/tests.rs
+++ b/compiler/src/tests.rs
@@ -6,7 +6,10 @@ mod tests_ {
     path::PathBuf,
   };
 
-  use summon_vm::vs_value::{ToVal, Val};
+  use summon_vm::{
+    circuit::CircuitInput,
+    vs_value::{ToVal, Val},
+  };
 
   use crate::{compile, resolve_entry_path::resolve_entry_path, DiagnosticsByPath};
 
@@ -43,7 +46,15 @@ mod tests_ {
       let inputs = circuit
         .inputs
         .iter()
-        .map(|(name, i)| (name.clone(), input[*i]))
+        .map(
+          |(
+            name,
+            CircuitInput {
+              wire_id,
+              type_json: _,
+            },
+          )| (name.clone(), input[*wire_id]),
+        )
         .collect::<BTreeMap<_, _>>();
 
       let outputs = circuit.eval(&inputs);

--- a/examples/boolIO.ts
+++ b/examples/boolIO.ts
@@ -1,0 +1,11 @@
+//! test [false, false] => [false]
+//! test [false,  true] => [false]
+//! test [ true, false] => [false]
+//! test [ true,  true] => [ true]
+
+export default (io: Summon.IO) => {
+  const x = io.input('alice', 'x', summon.bool());
+  const y = io.input('alice', 'y', summon.bool());
+
+  io.outputPublic('result', x && y);
+}

--- a/examples/exercises/approvalVoting.ts
+++ b/examples/exercises/approvalVoting.ts
@@ -7,7 +7,7 @@
 // most approvals.
 //
 // Example:
-//  //! test { N: 6 } [1, 1, 0,   1, 1, 0,   0, 1, 0,   0, 1, 1,   0, 1, 1,   0, 1, 1] => [1]
+//  //! test { N: 6 } [true, true, false,   true, true, false,   false, true, false,   false, true, true,   false, true, true,   false, true, true] => [1]
 //
 // Output meanings:
 //   0: Steak Shack
@@ -33,9 +33,9 @@ type Ballot = {
 
 function inputBallot(io: Summon.IO, partyIndex: number): Ballot {
   return {
-    steakShack: io.input(`party${partyIndex}`, `steakShack${partyIndex}`, summon.number()) !== 0,
-    burgerBarn: io.input(`party${partyIndex}`, `burgerBarn${partyIndex}`, summon.number()) !== 0,
-    veggieVilla: io.input(`party${partyIndex}`, `veggieVilla${partyIndex}`, summon.number()) !== 0,
+    steakShack: io.input(`party${partyIndex}`, `steakShack${partyIndex}`, summon.bool()),
+    burgerBarn: io.input(`party${partyIndex}`, `burgerBarn${partyIndex}`, summon.bool()),
+    veggieVilla: io.input(`party${partyIndex}`, `veggieVilla${partyIndex}`, summon.bool()),
   };
 }
 

--- a/examples/exercises/checkSuperMajority.ts
+++ b/examples/exercises/checkSuperMajority.ts
@@ -5,10 +5,10 @@
 // The circuit should return 1 to indicate the motion passes and 0 to indicate it fails.
 //
 // For example:
-//  //! test [0, 0, 0, 0, 0, 0, 0, 0, 0, 0] => [0]
-//  //! test [1, 1, 1, 1, 1, 1, 1, 1, 1, 1] => [1]
-//  //! test [0, 7, 8, 0, 1, 1, 0, 0, 2, 2] => [0]
-//  //! test [0, 7, 8, 0, 1, 1, 0, 3, 2, 2] => [1]
+//  //! test [false, false, false, false, false, false, false, false, false, false] => [false]
+//  //! test [ true,  true,  true,  true,  true,  true,  true,  true,  true,  true] => [ true]
+//  //! test [false,  true,  true, false,  true,  true, false, false,  true,  true] => [false]
+//  //! test [false,  true,  true, false,  true,  true, false,  true,  true,  true] => [ true]
 //
 // The format above is also used to check circuits with `cargo test`. Simply move them to their own
 // line, similar to test annotations in `loopAdd.ts` and `greaterThan10.ts`.
@@ -19,22 +19,22 @@ export default function main(io: Summon.IO) {
   // use that to dynamically gather the inputs. See `medianCircuit.ts` for an example.
 
   const ballots = [
-    io.input('party0', 'ballot0', summon.number()),
-    io.input('party1', 'ballot1', summon.number()),
-    io.input('party2', 'ballot2', summon.number()),
-    io.input('party3', 'ballot3', summon.number()),
-    io.input('party4', 'ballot4', summon.number()),
-    io.input('party5', 'ballot5', summon.number()),
-    io.input('party6', 'ballot6', summon.number()),
-    io.input('party7', 'ballot7', summon.number()),
-    io.input('party8', 'ballot8', summon.number()),
-    io.input('party9', 'ballot9', summon.number()),
+    io.input('party0', 'ballot0', summon.bool()),
+    io.input('party1', 'ballot1', summon.bool()),
+    io.input('party2', 'ballot2', summon.bool()),
+    io.input('party3', 'ballot3', summon.bool()),
+    io.input('party4', 'ballot4', summon.bool()),
+    io.input('party5', 'ballot5', summon.bool()),
+    io.input('party6', 'ballot6', summon.bool()),
+    io.input('party7', 'ballot7', summon.bool()),
+    io.input('party8', 'ballot8', summon.bool()),
+    io.input('party9', 'ballot9', summon.bool()),
   ];
 
   io.outputPublic('result', impl(ballots) ? 1 : 0);
 }
 
-function impl(ballots: number[]): boolean {
+function impl(ballots: boolean[]): boolean {
   // TODO: Return true iff 2/3 or more ballots are non-zero. (In the resulting circuit, true will
   // be converted to 1 and false will be converted to 0.)
   throw new Error('Implement me');

--- a/summon.d.ts
+++ b/summon.d.ts
@@ -16,6 +16,9 @@ declare const summon: {
 
   /** Produces a runtime value that models the type `number`. */
   number(): Summon.Type<number>;
+
+  /** Produces a runtime value that models the type `boolean`. */
+  bool(): Summon.Type<boolean>;
 };
 
 declare namespace Summon {

--- a/vm/src/builtins/summon_builtin.rs
+++ b/vm/src/builtins/summon_builtin.rs
@@ -21,6 +21,7 @@ impl BuiltinObject for SummonBuiltin {
     match key {
       "isSignal" => IS_SIGNAL.to_val(),
       "number" => NUMBER.to_val(),
+      "bool" => BOOL.to_val(),
 
       _ => Val::Undefined,
     }
@@ -57,5 +58,16 @@ static NUMBER: NativeFunction = native_fn(|_this, params| {
   Ok(Val::make_object(&[
     ("about", "summon runtime type".to_val()),
     ("json", "number".to_val()),
+  ]))
+});
+
+static BOOL: NativeFunction = native_fn(|_this, params| {
+  if !params.is_empty() {
+    return Err("Unexpected arguments".to_type_error());
+  }
+
+  Ok(Val::make_object(&[
+    ("about", "summon runtime type".to_val()),
+    ("json", "bool".to_val()),
   ]))
 });

--- a/vm/src/circuit.rs
+++ b/vm/src/circuit.rs
@@ -1,4 +1,4 @@
-use std::{cmp::max, collections::BTreeMap};
+use std::{cmp::max, collections::BTreeMap, fmt};
 
 use crate::{binary_op::BinaryOp, unary_op::UnaryOp};
 use bristol_circuit::{BristolCircuit, CircuitInfo, ConstantInfo, Gate as BristolGate, IOInfo};
@@ -232,65 +232,106 @@ pub trait CircuitNumber: Clone {
   fn binary_op(op: BinaryOp, left: &Self, right: &Self) -> Self;
 }
 
-impl CircuitNumber for usize {
+#[derive(Clone, Debug)]
+pub enum NumberOrBool {
+  Number(usize),
+  Bool(bool),
+}
+
+impl NumberOrBool {
+  fn as_usize(&self) -> usize {
+    match self {
+      NumberOrBool::Number(x) => *x,
+      NumberOrBool::Bool(x) => *x as usize,
+    }
+  }
+
+  fn as_bool(&self) -> bool {
+    match self {
+      NumberOrBool::Number(x) => *x != 0,
+      NumberOrBool::Bool(x) => *x,
+    }
+  }
+}
+
+impl PartialEq for NumberOrBool {
+  fn eq(&self, other: &Self) -> bool {
+    match (self, other) {
+      (NumberOrBool::Number(a), NumberOrBool::Number(b)) => a == b,
+      (NumberOrBool::Bool(a), NumberOrBool::Bool(b)) => a == b,
+      _ => false, // Different variants are not equal
+    }
+  }
+}
+
+impl fmt::Display for NumberOrBool {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      NumberOrBool::Number(x) => write!(f, "{}", x),
+      NumberOrBool::Bool(x) => write!(f, "{}", x),
+    }
+  }
+}
+
+impl CircuitNumber for NumberOrBool {
   fn zero() -> Self {
-    0
+    NumberOrBool::Number(0)
   }
 
   fn from_json(x: &serde_json::Value) -> Self {
     if let Some(x) = x.as_u64() {
-      return x as usize;
+      return NumberOrBool::Number(x as usize);
     }
 
     if let Some(x) = x.as_bool() {
-      return if x { 1 } else { 0 };
+      return NumberOrBool::Bool(x);
     }
 
-    panic!("Couldn't convert to usize: {}", x);
+    panic!("Couldn't convert to NumberOrBool: {}", x);
   }
 
-  // fn from_usize(x: usize) -> Self {
-  //   x
-  // }
-
   fn unary_op(op: UnaryOp, input: &Self) -> Self {
-    let input = *input;
-
     match op {
-      UnaryOp::Plus => input,
-      UnaryOp::Minus => 0usize.wrapping_sub(input),
-      UnaryOp::Not => (input == 0) as usize,
-      UnaryOp::BitNot => !input,
+      UnaryOp::Plus => input.clone(),
+      UnaryOp::Minus => NumberOrBool::Number(0usize.wrapping_sub(input.as_usize())),
+      UnaryOp::Not => match input {
+        NumberOrBool::Number(x) => NumberOrBool::Bool(*x == 0),
+        NumberOrBool::Bool(x) => NumberOrBool::Bool(!x),
+      },
+      UnaryOp::BitNot => NumberOrBool::Number(!input.as_usize()),
     }
   }
 
   fn binary_op(op: BinaryOp, left: &Self, right: &Self) -> Self {
-    let left = *left;
-    let right = *right;
-
     match op {
-      BinaryOp::Plus => left.wrapping_add(right),
-      BinaryOp::Minus => left.wrapping_sub(right),
-      BinaryOp::Mul => left.wrapping_mul(right),
-      BinaryOp::Div => left / right,
-      BinaryOp::Mod => left % right,
-      BinaryOp::Exp => left.wrapping_pow(right as u32),
-      BinaryOp::LooseEq => (left == right) as usize,
-      BinaryOp::LooseNe => (left != right) as usize,
-      BinaryOp::Eq => (left == right) as usize,
-      BinaryOp::Ne => (left != right) as usize,
-      BinaryOp::And => (left != 0 && right != 0) as usize,
-      BinaryOp::Or => (left != 0 || right != 0) as usize,
-      BinaryOp::Less => (left < right) as usize,
-      BinaryOp::LessEq => (left <= right) as usize,
-      BinaryOp::Greater => (left > right) as usize,
-      BinaryOp::GreaterEq => (left >= right) as usize,
-      BinaryOp::BitAnd => left & right,
-      BinaryOp::BitOr => left | right,
-      BinaryOp::BitXor => left ^ right,
-      BinaryOp::LeftShift => left.wrapping_shl(right as u32),
-      BinaryOp::RightShift => left.wrapping_shr(right as u32),
-      BinaryOp::RightShiftUnsigned => left.wrapping_shr(right as u32),
+      BinaryOp::Plus => NumberOrBool::Number(left.as_usize().wrapping_add(right.as_usize())),
+      BinaryOp::Minus => NumberOrBool::Number(left.as_usize().wrapping_sub(right.as_usize())),
+      BinaryOp::Mul => NumberOrBool::Number(left.as_usize().wrapping_mul(right.as_usize())),
+      BinaryOp::Div => NumberOrBool::Number(left.as_usize() / right.as_usize()),
+      BinaryOp::Mod => NumberOrBool::Number(left.as_usize() % right.as_usize()),
+      BinaryOp::Exp => NumberOrBool::Number(left.as_usize().wrapping_pow(right.as_usize() as u32)),
+      BinaryOp::LooseEq => NumberOrBool::Bool(left.as_usize() == right.as_usize()),
+      BinaryOp::LooseNe => NumberOrBool::Bool(left.as_usize() != right.as_usize()),
+      BinaryOp::Eq => NumberOrBool::Bool(left.as_usize() == right.as_usize()),
+      BinaryOp::Ne => NumberOrBool::Bool(left.as_usize() != right.as_usize()),
+      BinaryOp::And => NumberOrBool::Bool(left.as_bool() && right.as_bool()),
+      BinaryOp::Or => NumberOrBool::Bool(left.as_bool() || right.as_bool()),
+      BinaryOp::Less => NumberOrBool::Bool(left.as_usize() < right.as_usize()),
+      BinaryOp::LessEq => NumberOrBool::Bool(left.as_usize() <= right.as_usize()),
+      BinaryOp::Greater => NumberOrBool::Bool(left.as_usize() > right.as_usize()),
+      BinaryOp::GreaterEq => NumberOrBool::Bool(left.as_usize() >= right.as_usize()),
+      BinaryOp::BitAnd => NumberOrBool::Number(left.as_usize() & right.as_usize()),
+      BinaryOp::BitOr => NumberOrBool::Number(left.as_usize() | right.as_usize()),
+      BinaryOp::BitXor => NumberOrBool::Number(left.as_usize() ^ right.as_usize()),
+      BinaryOp::LeftShift => {
+        NumberOrBool::Number(left.as_usize().wrapping_shl(right.as_usize() as u32))
+      }
+      BinaryOp::RightShift => {
+        NumberOrBool::Number(left.as_usize().wrapping_shr(right.as_usize() as u32))
+      }
+      BinaryOp::RightShiftUnsigned => {
+        NumberOrBool::Number(left.as_usize().wrapping_shr(right.as_usize() as u32))
+      }
     }
   }
 }

--- a/vm/src/circuit_builder.rs
+++ b/vm/src/circuit_builder.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::{vs_value::Val, ValTrait};
 use num_traits::ToPrimitive;
+use serde_json::json;
 
 use crate::{
   circuit::Gate,
@@ -17,7 +18,7 @@ pub struct CircuitBuilder {
   pub wire_count: usize,
   pub wires_included: HashMap<usize, usize>, // CircuitSignal.id -> wire_id
   pub signal_data: Vec<Option<Box<CircuitSignalData>>>, // wire_id -> CircuitSignalData
-  pub constants: HashMap<usize, usize>,      // value -> wire_id
+  pub constants: HashMap<serde_json::Value, usize>, // value -> wire_id
 }
 
 impl CircuitBuilder {
@@ -57,7 +58,7 @@ impl CircuitBuilder {
   pub fn include_val_shallow(&mut self, val: &Val) -> usize {
     match val {
       Val::Bool(bool) => {
-        let value = if *bool { 1usize } else { 0usize };
+        let value = if *bool { json!(true) } else { json!(false) };
 
         if let Some(wire_id) = self.constants.get(&value) {
           return *wire_id;
@@ -78,6 +79,8 @@ impl CircuitBuilder {
         } else {
           number.to_usize().unwrap()
         };
+
+        let value = serde_json::Value::from(value);
 
         if let Some(wire_id) = self.constants.get(&value) {
           return *wire_id;


### PR DESCRIPTION
## What is this PR doing?

Adds boolean IO!

This means you can use `summon.bool()` with the `io.input()`, `io.inputPublic()`, and `io.outputPublic()` APIs instead of just `summon.number()`.

In particular, when you use `--boolify-width`, your bools will persist as single wires in the boolean circuit instead of being treated as numbers. This fixes issues with unnecessary wires and provides a nicer dev experience where APIs can consume and produce actual booleans instead of 0,1 to mirror what's going on inside the circuit.

One nice example is that the 2pc-is-for-lovers circuit will change from:

```ts
export default function main(a: number, b: number) {
  return a & b;
}
```

to:

```ts
export default function main(io: Summon.IO) {
  const aliceLovesBob = io.input('alice', 'aliceLovesBob', summon.bool());
  const bobLovesAlice = io.input('bob', 'bobLovesAlice', summon.bool());

  const mutualLove = aliceLovesBob && bobLovesAlice;

  io.outputPublic('mutualLove', mutualLove);
}
```

It may be more verbose, but it's pretty unintuitive that the best way to get a single `and` gate in the old system is to do a bitwise `and` and ask for 1-bit arithmetic. In the new system, you can just do exactly what you want without thinking about workarounds.

## How can these changes be manually tested?

`cargo test`
Take a look at `examples/boolIO.ts`
Also `approvalVoting.ts` and `checkSuperMajority.ts` in [exercise solutions](https://github.com/privacy-scaling-explorations/summon/tree/dece568/examples/exerciseSolutions).

## Does this PR resolve or contribute to any issues?

Contributes to https://www.notion.so/pse-team/Rich-IO-15ed57e8dd7e80058612d5519bff625b?pvs=4

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
