### PR TITLE
Use serde for public inputs

### DIFF
--- a/compiler/src/compile.rs
+++ b/compiler/src/compile.rs
@@ -36,8 +36,8 @@ pub struct CompileLinkedModuleResult {
 }
 
 pub fn compile<ReadFile>(
-  public_inputs: &HashMap<String, Val>,
   path: ResolvedPath,
+  public_inputs: &HashMap<String, serde_json::Value>,
   read_file: ReadFile,
 ) -> CompileResult
 where
@@ -66,7 +66,13 @@ where
   }
 
   let id_gen = Rc::new(RefCell::new(IdGenerator::new()));
-  let io = SummonIO::new(public_inputs, &id_gen);
+
+  let public_inputs = public_inputs
+    .iter()
+    .map(|(name, value)| (name.clone(), Val::from_json(value)))
+    .collect::<HashMap<_, _>>();
+
+  let io = SummonIO::new(&public_inputs, &id_gen);
   run(main, &io);
 
   for unused_input in io.unused_public_inputs() {

--- a/compiler/src/tests.rs
+++ b/compiler/src/tests.rs
@@ -6,10 +6,7 @@ mod tests_ {
     path::PathBuf,
   };
 
-  use summon_vm::{
-    circuit::{CircuitInput, CircuitNumber, NumberOrBool},
-    vs_value::{ToVal, Val},
-  };
+  use summon_vm::circuit::{CircuitInput, CircuitNumber, NumberOrBool};
 
   use crate::{compile, resolve_entry_path::resolve_entry_path, DiagnosticsByPath};
 
@@ -30,7 +27,7 @@ mod tests_ {
 
       let path = resolve_entry_path(path);
 
-      let compile_result = compile(public_inputs, path.clone(), |p| {
+      let compile_result = compile(path.clone(), public_inputs, |p| {
         fs::read_to_string(p).map_err(|e| e.to_string())
       });
 
@@ -96,7 +93,7 @@ mod tests_ {
   struct TestCase {
     path: String,
     descriptor: String,
-    public_inputs: HashMap<String, Val>,
+    public_inputs: HashMap<String, serde_json::Value>,
     input: Vec<serde_json::Value>,
     expected_output: Vec<serde_json::Value>,
   }
@@ -135,7 +132,7 @@ mod tests_ {
         let val = val_str
           .parse::<usize>()
           .unwrap_or_else(|_| panic!("invalid usize `{}` in public_inputs", val_str));
-        public_inputs.insert(key, (val as f64).to_val());
+        public_inputs.insert(key, val.into());
       }
 
       // advance rest past the '}' and any following whitespace


### PR DESCRIPTION
## What is this PR doing?

Simplifies the `compile` api by using `serde_json::Value` instead of `Val`. (`Val` is summon's internal model of values, and `serde_json::Value` is a bit easier to deal with.)

## How can these changes be manually tested?

`cargo test`

## Does this PR resolve or contribute to any issues?

Contributes to https://www.notion.so/pse-team/Rich-IO-15ed57e8dd7e80058612d5519bff625b?pvs=4

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
