### PR TITLE
avoid usize conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 [[package]]
 name = "boolify"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/boolify?rev=380a815#380a81588ac8e262f563e0158b65e4db03da1554"
+source = "git+https://github.com/voltrevo/boolify?rev=a5e5dd3#a5e5dd368b11873d2c7d91d356ba5f37afe11556"
 dependencies = [
  "bristol-circuit",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.dependencies]
 bincode = "2"
-boolify = { git = "https://github.com/voltrevo/boolify", rev = "380a815" }
+boolify = { git = "https://github.com/voltrevo/boolify", rev = "a5e5dd3" }
 bristol-circuit = { git = "https://github.com/voltrevo/bristol-circuit", rev = "10ee9c7" }
 num-bigint = "0.4"
 num-derive = "0.4"

--- a/examples/largeConstant.ts
+++ b/examples/largeConstant.ts
@@ -1,0 +1,10 @@
+//! test [1000000000000] => [false]
+//! test [1000000000001] => [true]
+
+const oneTrillion = 1_000_000_000_000;
+
+export default (io: Summon.IO) => {
+  const a = io.input('alice', 'a', summon.number());
+
+  io.outputPublic('greaterThan1T', a > oneTrillion);
+};

--- a/vm/src/circuit.rs
+++ b/vm/src/circuit.rs
@@ -279,7 +279,7 @@ impl CircuitNumber for NumberOrBool {
   }
 
   fn from_json(x: &serde_json::Value) -> Self {
-    if let Some(x) = x.as_u64() {
+    if let Some(x) = x.as_f64() {
       return NumberOrBool::Number(x as usize);
     }
 

--- a/vm/src/circuit_builder.rs
+++ b/vm/src/circuit_builder.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use crate::{vs_value::Val, ValTrait};
-use num_traits::ToPrimitive;
 use serde_json::json;
 
 use crate::{
@@ -74,13 +73,7 @@ impl CircuitBuilder {
           panic!("Cannot use non-integer constant");
         }
 
-        let value = if *number < 0.0 {
-          usize::MAX - ((-number).to_usize().unwrap() - 1)
-        } else {
-          number.to_usize().unwrap()
-        };
-
-        let value = serde_json::Value::from(value);
+        let value = serde_json::Value::from(*number);
 
         if let Some(wire_id) = self.constants.get(&value) {
           return *wire_id;


### PR DESCRIPTION
## What is this PR doing?

Avoids unnecessary usize conversion when including constants into arithmetic circuits. This is a problem when compiling for 32-bit, which is needed for browser wasm, because u32 is unnecessarily restrictive. This was motivated by the need for a one trillion constant in the Ballpark circuit.

## How can these changes be manually tested?

Run the tests (see added test).

## Does this PR resolve or contribute to any issues?

Nope.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
